### PR TITLE
Fix typos in LPPL notice

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,4 +11,4 @@ See the documentation for typeset examples and caveats.
 Copyright (C) 2025 plante
 Version 1.0a
 
-This package is relased under the LaTeX Project Public License (LPPL) 1.3c.
+This package is released under the LaTeX Project Public License (LPPL) 1.3c.

--- a/visualtoks-doc.tex
+++ b/visualtoks-doc.tex
@@ -106,7 +106,7 @@ It is assumed that \verb|{| and \verb|}| are the only characters with category c
 \subsection*{License}
 
 This package is copyright \copyright\ 2025 plante, and
-relased under the \LaTeX\ Project Public License (\textsc{lppl}) 1.3c.
+released under the \LaTeX\ Project Public License (\textsc{lppl}) 1.3c.
 
 \subsection*{Repository}
 

--- a/visualtoks.tex
+++ b/visualtoks.tex
@@ -1,7 +1,7 @@
 % visualtoks.tex, version 1.0a
 
 % Copyright (C) 2025 plante
-% This package is relased under the LaTeX Project Public License (LPPL) 1.3c.
+% This package is released under the LaTeX Project Public License (LPPL) 1.3c.
 
 % visualtoks: typeset TeXbook-style visualisations of token lists.
 


### PR DESCRIPTION
The first occurrence was caught by myself, then with the help of [`typos`](https://github.com/crate-ci/typos) tool, all were caught and corrected.

I didn't rebuild and update the PDF documentation.

```
# list typos
$ typos
error: `relased` should be `released`
  --> ./README.md:14:17
   |
14 | This package is relased under the LaTeX Project Public License (LPPL) 1.3c.
   |                 ^^^^^^^
   |
error: `relased` should be `released`
  --> ./visualtoks.tex:4:19
  |
4 | % This package is relased under the LaTeX Project Public License (LPPL) 1.3c.
  |                   ^^^^^^^
  |
error: `relased` should be `released`
  --> ./visualtoks-doc.tex:109:1
    |
109 | relased under the \LaTeX\ Project Public License (\textsc{lppl}) 1.3c.
    | ^^^^^^^
    |

# correct typos (-w, --write-changes)
$ typos -w
```